### PR TITLE
Prevent JS breakage if multiple files define translations for same locale

### DIFF
--- a/lib/i18n-js-assets/processor.rb
+++ b/lib/i18n-js-assets/processor.rb
@@ -38,7 +38,7 @@ module I18nJsAssets
     end
 
     def construct_javascript_for_locale(locale, translations)
-      %(I18n.translations["#{locale}"] = #{translations.to_json};\n)
+      %{I18n.translations["#{locale}"] = I18n.extend((I18n.translations["#{locale}"] || {}), #{translations.to_json});\n}
     end
 
     def i18n_js

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,11 @@ module LetDeclarations
   extend RSpec::SharedContext
 
   let(:en_source) do
-    %Q(I18n.translations["en"] = {"my_app":{"teapot":"I'm a little teapot"}};)
+    %Q(I18n.translations["en"] = I18n.extend((I18n.translations["en"] || {}), {"my_app":{"teapot":"I'm a little teapot"}});)
   end
 
   let(:es_source) do
-    %Q(I18n.translations["es"] = {"my_app":{"teapot":"Soy una tetera pequeña"}};)
+    %Q(I18n.translations["es"] = I18n.extend((I18n.translations["es"] || {}), {"my_app":{"teapot":"Soy una tetera pequeña"}});)
   end
 
   let(:assets_config) do


### PR DESCRIPTION
In my use case, we have a sitewide JS file which has translations for
some global widgets, and then sometimes page-specific files with more
translations for that page
