### PR TITLE
Caching: add a digest of .yml file contents to the list of environment paths

### DIFF
--- a/lib/i18n-js-assets/railtie.rb
+++ b/lib/i18n-js-assets/railtie.rb
@@ -8,24 +8,21 @@ module I18nJsAssets
 
     config.before_configuration do |app|
       app.config.assets.localized = I18nJsAssets::Manifest.new(app)
-
-      # At this point, application locales are not yet part of I18n.load_path.
-      # Ideally, this would be done after I18n.load_path is fully initialzed
-      # However, by that time Sprockets will already have made a copy of app.config.assets.paths
-      # To ensure that updated i18n assets get reloaded, we need to make sure Sprockets knows about the .yml dependencies.
-      # Getting the dependencies through config.assets.paths seems to be the best solution for now
-      # However, ideally, these dependencies would come directly from i18n files, so only affected files are reloaded
-      # (config.assets.paths changing causes a full recompile of the asset cache)
-      i18n_paths = I18n.load_path.to_set + Dir[Rails.root.join('config', 'locales', '*.{rb,yml}').to_s]
-      digest = Digest::SHA256.new
-      i18n_paths.each { |path| digest << File.read(path) }
-      app.config.assets.paths << File.join("#{GeneratedAssets.asset_dir}/i18n-js-assets-#{digest.hexdigest}", app.class.parent_name)
     end
 
     config.before_initialize do |app|
       app.config.assets.generated.before_apply do
         app.config.assets.localized.apply!
       end
+    end
+
+    config.assets.configure do |env|
+      # To ensure that updated i18n assets get reloaded, we need to make sure Sprockets knows about the .yml dependencies.
+      # Changing the dependencies via environment-paths (generated based off env.paths which we modify here) seems to be the best solution for now
+      # The downside is that the entire cache is recompiled when an i18n .yml changes
+      digest = Digest::SHA256.new
+      I18n.load_path.each { |path| digest << File.read(path) }
+      env.append_path(File.join("#{GeneratedAssets.asset_dir}/i18n-js-assets-#{digest.hexdigest}"))
     end
 
     # this is for certain versions of rails 3 and rails 4

--- a/lib/i18n-js-assets/railtie.rb
+++ b/lib/i18n-js-assets/railtie.rb
@@ -33,11 +33,11 @@ module I18nJsAssets
     # this is for rails 3/4, sprockets < 4
     if !sprockets4?
       initializer :i18n_js_assets, after: 'sprockets.environment' do |app|
-        if app.assets
-          app.assets.register_engine('.i18njs', I18nJsAssets::Processor)
+        assets = app.assets || app.config.assets
+        if assets
+          assets.register_engine('.i18njs', I18nJsAssets::Processor)
+          assets.append_path(i18n_state_digest_path)
         end
-
-        app.assets.append_path(i18n_state_digest_path)
       end
     end
 


### PR DESCRIPTION
This forces the asset pipeline to recompile files dependent on environment paths when .yml files change.
This used to be achieved through generated-assets, but did it w/o checking that .yml files actually got changed.
