### PR TITLE
Automatically recompile .i18njs assets when .yml files change

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -30,3 +30,7 @@
 == 2.1.0
 
 * Support for Rails 5.
+
+== 2.2.0
+
+* .i18njs files now depend_on files in the I18n load path so they get automatically recompiled (i.e. in development) if one of your .yml files changes.

--- a/lib/i18n-js-assets/transformer.rb
+++ b/lib/i18n-js-assets/transformer.rb
@@ -10,6 +10,12 @@ module I18nJsAssets
         only = options.fetch(:only, '*')
         exceptions = [options.fetch(:except, [])].flatten
 
+        # add dependencies to this asset so that any changes to files on the
+        # I18n load path cause this asset to be recompiled
+        I18n.load_path.each do |path|
+          context.depend_on(path)
+        end
+
         # handle newer and older versions of i18n-js
         translations = if i18n_js.method(:segment_for_scope).arity == 2
           i18n_js.segment_for_scope(only, exceptions)

--- a/lib/i18n-js-assets/version.rb
+++ b/lib/i18n-js-assets/version.rb
@@ -1,5 +1,5 @@
 # encoding: UTF-8
 
 module I18nJsAssets
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Related to https://github.com/camertron/generated-assets/issues/4 and hopefully fixes it by enabling hot reloading. Makes the .yml files dependencies of .i18njs files so they're automatically recompiled if the .yml files change. Should make development a bit easier and eliminate the need to run `rake tmp:cache:clear` between app restarts.